### PR TITLE
#26 Fixed H3 Title margin for sidebar headers.

### DIFF
--- a/app/assets/stylesheets/wigu/active_admin_theme.scss
+++ b/app/assets/stylesheets/wigu/active_admin_theme.scss
@@ -553,6 +553,7 @@ form fieldset.inputs {
      color: #ffffff;
      border: none;
      padding: 8px 15px;
+     margin-top: 0;
      font-weight: 400;
 
      -webkit-border-top-left-radius: $skinBorderRadius;


### PR DESCRIPTION
This fix tested on ActiveAdmin versions 1.0.0.pre2 and 1.3.1.
Browsers: Lasts Chrome, Firefox, Safari, Edge

Results:

![2018-10-23 16 01 34](https://user-images.githubusercontent.com/12969204/47362755-d4234d80-d6dd-11e8-9de2-a6f4b8f6aca5.png)
![2018-10-09 16 25 50](https://user-images.githubusercontent.com/12969204/47362884-24021480-d6de-11e8-8368-bd1edf784408.png)
