### PR TITLE
bug: the buttons than have class .button_action and links with class …

### DIFF
--- a/app/assets/stylesheets/wigu/active_admin_theme.scss
+++ b/app/assets/stylesheets/wigu/active_admin_theme.scss
@@ -138,6 +138,7 @@ body.active_admin {
         @include rounded($skinBorderRadius);
         background-color: $skinMainSecondColor;
         border: none;
+        padding: 10px 20px;
         color: #ffffff;
         font-weight: 600;
         &:hover {


### PR DESCRIPTION
….action_item do not have same heigth

each input/button/a/a.dropdown_menu_button must have same heigth than contains in .titlebar_right div


