### PR TITLE
Add NPM Module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Custom ActiveAdmin templates
 ## Installation
 As active_skin is the css theme for the [activeadmin](https://github.com/activeadmin/activeadmin) administration framework - you have to install if first.
 
+#### As a Gem
 Having active admin installed add the following line to your application's Gemfile:
 
 
@@ -21,11 +22,41 @@ Or install it yourself as:
 
     $ gem install active_admin_theme
 
+#### As a NPM module (Yarn package)
+Execute:
+
+    $ npm i @activeadmin-plugins/active_admin_theme
+
+Or
+
+    $ yarn add @activeadmin-plugins/active_admin_theme
+
+Or add manually to `package.json`:
+
+```
+"dependencies": {
+  "@activeadmin-plugins/active_admin_theme": "1.1.4"
+}
+```
+and execute:
+
+    $ yarn
+
 ## Usage
 
+In your base stylesheet entry point `active_admin.scss` (as example), add line:
+
+#### As a Gem via Sprockets
 ```css
-@import "wigu/active_admin_theme";
+@import 'wigu/active_admin_theme';
 ```
+
+#### As a NPM module (Yarn package) via Webpacker or any other assets bundler
+
+```css
+@import '@activeadmin-plugins/active_admin_theme';
+```
+
 You can change basic colors of the theme by setting some variable above active_admin_theme import line in active_admin.css.scss
 
 ```css
@@ -34,7 +65,7 @@ $skinMainFirstColor: #A5A7AA!default;
 $skinMainSecondColor: #0066CC!default;
 $skinBorderWindowColor: #B8BABE!default;
 
-@import "wigu/active_admin_theme";
+@import 'wigu/active_admin_theme';
 ...
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@activeadmin-plugins/active_admin_theme",
+  "version": "1.1.4",
+  "description": "Flat design for ActiveAdmin",
+  "main": "src/active_admin_theme.scss",
+  "author": "Igor Fedoronchuk <igor.f@didww.com>",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeadmin-plugins/active_admin_theme.git"
+  },
+  "bugs": {
+    "url": "https://github.com/activeadmin-plugins/active_admin_theme/issues"
+  },
+  "homepage": "https://github.com/activeadmin-plugins/active_admin_theme#readme",
+  "keywords": [
+    "active",
+    "admin",
+    "theme"
+  ],
+  "files": [
+    "src/**/*"
+  ],
+  "scripts": {
+    "prepublishOnly": "rm -rf src && cp -R app/assets/stylesheets/wigu/ src"
+  }
+}


### PR DESCRIPTION
This PR adds support to use this repo as an NPM/Yarn package so we can use it with Webpacker or any other assets bundler.
I implemented this so it uses the same source files as the Rails gem so any change in the CSS is available in both cases. I didn't change the Rails gem-related code this same repo can be used in both ways.

After pack&publish NPM module has minimum files and should look like:
![active-admin-theme-pack](https://user-images.githubusercontent.com/22831505/154750014-60bac001-9bde-44ec-a592-884be6911d46.png)

