### PR TITLE
Add active_admin_sidebar toggle button styling

### DIFF
--- a/app/assets/stylesheets/wigu/active_admin_theme.scss
+++ b/app/assets/stylesheets/wigu/active_admin_theme.scss
@@ -376,6 +376,15 @@ body.active_admin {
       padding: $skinTablePadding 12px $skinTablePadding 12px;
     }
   }
+  // active_admin_sidebar: align toggle button with sidebar section (no top margin in theme)
+  #active_admin_content.collapsible_sidebar .sidebar_toggle_btn {
+    top: 0;
+    background-color: $skinMainSecondColor;
+    &:hover {
+      background-color: lighten($skinMainSecondColor, 5%);
+    }
+  }
+
   .sidebar_section.panel {
     background-image: none;
     box-shadow: none;


### PR DESCRIPTION
## Summary
- Align collapsible sidebar toggle button (top: 0) to match theme sidebar panel layout (theme removes default 12px margin)
- Style toggle button with theme accent color instead of default gray
- Backward compatible — styles only apply when active_admin_sidebar gem is loaded

## Test plan
- [x] Verify toggle button aligns with sidebar panel when using active_admin_sidebar gem
- [x] Verify no visual changes when active_admin_sidebar gem is not installed
- [x] Verify button color matches theme accent on hover