### PR TITLE
Modernize gemspec: require Ruby 3.1+, add activeadmin dependency

### DIFF
--- a/active_admin_theme.gemspec
+++ b/active_admin_theme.gemspec
@@ -10,14 +10,15 @@ Gem::Specification.new do |spec|
   spec.email         = ["igor.f@didww.com", "alex.s@didww.com"]
   spec.summary       = %q{Flat design for ActiveAdmin}
   spec.description   = %q{Flat design for activeadmin gem }
-  spec.homepage      = "https://github.com/didww/active_admin_theme"
+  spec.homepage      = "https://github.com/activeadmin-plugins/active_admin_theme"
   spec.license       = "MIT"
+
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_dependency "activeadmin", ">= 3.0", "< 4.0"
 end


### PR DESCRIPTION
## Summary
- Update homepage URL to activeadmin-plugins org
- Add required_ruby_version >= 3.1.0 (drop support for older Rubies)
- Add activeadmin >= 3.0, < 4.0 as runtime dependency (supports AA 3.2-3.5, Rails 7.1/7.2/8.0)
- Remove outdated bundler ~> 1.7 and rake dev dependencies