### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/lib/active_admin_theme/version.rb
+++ b/lib/active_admin_theme/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminTheme
-  VERSION = "1.1.4"
+  VERSION = "2.0.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activeadmin-plugins/active_admin_theme",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Flat design for ActiveAdmin",
   "main": "src/active_admin_theme.scss",
   "author": "Igor Fedoronchuk <igor.f@didww.com>",


### PR DESCRIPTION
## Summary
- Bump gem version to 2.0.0 in version.rb
- Bump npm package version to 2.0.0 in package.json

Major version bump because:
- Dropped support for old Ruby (now requires >= 3.1.0)
- Dropped support for old ActiveAdmin (now requires >= 3.0)

Merge after #43 and #44 are merged, then release:
- Gem: rake release
- NPM: npm publish --access public